### PR TITLE
Make installation slightly more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ To run the example, perform the following:
  * Clone the repo
  * run `bundle install`
  * run `yarn`
- * run rails db:create
- * run rails db:migrate
+ * run `rails db:create`
+ * run `rails db:migrate`
  * run `bin/dev` 
    * This will install foreman the first time if you dont have it already installed. If this is the case you will need to run `bin/dev` again
  * Visit `localhost:3000` in your browser, app should be running  


### PR DESCRIPTION
Call out the `rails db:create` and `rails db:migrate` commands like the rest of the commands in the **Installation** section of the readme.